### PR TITLE
Cast Current, RPP, and Total to integers when set. Fixes #10

### DIFF
--- a/Pagination.class.php
+++ b/Pagination.class.php
@@ -334,7 +334,7 @@
          */
         public function setCurrent($current)
         {
-            $this->_variables['current'] = $current;
+            $this->_variables['current'] = (int)$current;
         }
 
         /**
@@ -405,7 +405,7 @@
          */
         public function setRPP($rpp)
         {
-            $this->_variables['rpp'] = $rpp;
+            $this->_variables['rpp'] = (int)$rpp;
         }
 
         /**
@@ -433,6 +433,6 @@
          */
         public function setTotal($total)
         {
-            $this->_variables['total'] = $total;
+            $this->_variables['total'] = (int)$total;
         }
     }


### PR DESCRIPTION
Here is some example code that demonstrates the issue:

```
<?php

// source inclusion
require_once 'Pagination.class.php';

// determine page (based on <_GET>), but do not cast to (int)
$page = isset($_GET['page']) ? $_GET['page'] : 1;

// instantiate; set current page; set number of records
$pagination = (new Pagination());
$pagination->setCurrent($page);
$pagination->setTotal(200);

// grab rendered/parsed pagination markup
$markup = $pagination->parse();

$base_url = parse_url($_SERVER["REQUEST_URI"], PHP_URL_PATH);

$url_raw = $base_url;
$url_broken = $base_url . "?page=1";

?>

<div>
    <?=$markup?>
</div>
<a href="<?=$url_raw?>">Raw (working) URL, without ?page</a><br />
<a href="<?=$url_broken?>">Broken URL, with ?page</a><br />
```

Without this fix, when a string value (raw from $_GET) is passed to setCurrent (the above "Broken URL"):

`« Previous
-1
0
1
2
3
Next »`

With this fix:

`« Previous
1
2
3
4
5
Next »`